### PR TITLE
Add slopOS web desktop and GitHub Pages–ready site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
 # slopOS
-an os made by ai
+
+A browser-based web OS experience built for GitHub Pages.
+
+## GitHub Pages
+
+1. Push this repo to GitHub.
+2. In **Settings → Pages**, choose **Deploy from a branch** and select the `main` branch with `/root`.
+3. Save and open the published URL.
+
+## Local preview
+
+```bash
+python3 -m http.server 8000
+```
+
+Then visit <http://localhost:8000>.

--- a/app.js
+++ b/app.js
@@ -1,0 +1,126 @@
+const bootScreen = document.getElementById("bootScreen");
+const desktop = document.getElementById("desktop");
+const status = document.getElementById("status");
+const windowPane = document.getElementById("window");
+const windowTitle = document.getElementById("windowTitle");
+const windowBody = document.getElementById("windowBody");
+const minimize = document.getElementById("minimize");
+const closeButton = document.getElementById("close");
+const templates = document.getElementById("templates");
+
+const appState = {
+  activeApp: "about",
+  notesKey: "slopOS-notes",
+};
+
+const appContent = {
+  about: {
+    title: "About slopOS",
+  },
+  notes: {
+    title: "Notes",
+  },
+  terminal: {
+    title: "Terminal",
+  },
+  gallery: {
+    title: "Gallery",
+  },
+};
+
+const terminalResponses = {
+  help: "Available commands: help, status, clear, time",
+  status: "All systems nominal. Network uplink stable.",
+};
+
+const setStatus = () => {
+  const now = new Date();
+  status.textContent = `${now.toLocaleDateString()} · ${now.toLocaleTimeString()}`;
+};
+
+const renderApp = (appName) => {
+  appState.activeApp = appName;
+  const template = templates.content.querySelector(
+    `[data-template="${appName}"]`
+  );
+
+  if (!template) {
+    return;
+  }
+
+  windowTitle.textContent = appContent[appName]?.title ?? "App";
+  windowBody.innerHTML = "";
+  windowBody.appendChild(template.cloneNode(true));
+
+  if (appName === "notes") {
+    const notesArea = windowBody.querySelector("#notesArea");
+    notesArea.value = localStorage.getItem(appState.notesKey) ?? "";
+    notesArea.addEventListener("input", (event) => {
+      localStorage.setItem(appState.notesKey, event.target.value);
+    });
+  }
+
+  if (appName === "terminal") {
+    const output = windowBody.querySelector("#terminalOutput");
+    const form = windowBody.querySelector("#terminalForm");
+    const input = windowBody.querySelector("#terminalInput");
+
+    const appendLine = (line) => {
+      const p = document.createElement("p");
+      p.textContent = line;
+      output.appendChild(p);
+      output.scrollTop = output.scrollHeight;
+    };
+
+    appendLine("Type 'help' for a command list.");
+
+    form.addEventListener("submit", (event) => {
+      event.preventDefault();
+      const command = input.value.trim();
+      if (!command) {
+        return;
+      }
+      appendLine(`$ ${command}`);
+      if (command === "clear") {
+        output.innerHTML = "";
+      } else if (command === "time") {
+        appendLine(new Date().toLocaleString());
+      } else {
+        appendLine(terminalResponses[command] ?? `Unknown command: ${command}`);
+      }
+      input.value = "";
+    });
+  }
+};
+
+const attachAppLaunchers = () => {
+  document.querySelectorAll("[data-app]").forEach((button) => {
+    button.addEventListener("click", () => {
+      const app = button.dataset.app;
+      if (app === "launcher") {
+        windowPane.classList.remove("minimized");
+        return;
+      }
+      renderApp(app);
+      windowPane.classList.remove("minimized");
+    });
+  });
+};
+
+minimize.addEventListener("click", () => {
+  windowPane.classList.toggle("minimized");
+});
+
+closeButton.addEventListener("click", () => {
+  windowPane.classList.add("minimized");
+});
+
+setInterval(setStatus, 1000);
+
+setTimeout(() => {
+  bootScreen.hidden = true;
+  desktop.hidden = false;
+  setStatus();
+  renderApp("about");
+  attachAppLaunchers();
+}, 1200);

--- a/index.html
+++ b/index.html
@@ -1,0 +1,114 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>slopOS Web</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <div class="boot-screen" id="bootScreen" aria-live="polite">
+      <div class="boot-logo">slopOS</div>
+      <p>Initializing web OS services…</p>
+      <div class="boot-bar"><span></span></div>
+    </div>
+
+    <div class="desktop" id="desktop" hidden>
+      <header class="top-bar">
+        <div class="brand">slopOS</div>
+        <div class="status" id="status">Loading…</div>
+      </header>
+
+      <main class="workspace" role="presentation">
+        <section class="icon-grid">
+          <button class="app-icon" data-app="about">
+            <span>🪐</span>
+            <strong>About</strong>
+          </button>
+          <button class="app-icon" data-app="notes">
+            <span>📝</span>
+            <strong>Notes</strong>
+          </button>
+          <button class="app-icon" data-app="terminal">
+            <span>💻</span>
+            <strong>Terminal</strong>
+          </button>
+          <button class="app-icon" data-app="gallery">
+            <span>🖼️</span>
+            <strong>Gallery</strong>
+          </button>
+        </section>
+
+        <section class="window" id="window" role="dialog" aria-modal="false">
+          <header class="window-header">
+            <h2 id="windowTitle">Welcome</h2>
+            <div class="window-actions">
+              <button id="minimize">_</button>
+              <button id="close">✕</button>
+            </div>
+          </header>
+          <div class="window-body" id="windowBody"></div>
+        </section>
+      </main>
+
+      <footer class="dock" role="navigation">
+        <button class="dock-button" data-app="launcher">Launchpad</button>
+        <div class="dock-divider"></div>
+        <button class="dock-button" data-app="about">About</button>
+        <button class="dock-button" data-app="notes">Notes</button>
+        <button class="dock-button" data-app="terminal">Terminal</button>
+        <button class="dock-button" data-app="gallery">Gallery</button>
+      </footer>
+    </div>
+
+    <template id="templates">
+      <article data-template="about">
+        <h3>Welcome to slopOS Web</h3>
+        <p>
+          slopOS is now a browser-first operating system shell with draggable
+          windows, persistent notes, and a lightweight "terminal".
+        </p>
+        <ul>
+          <li>Launch apps from the dock or desktop.</li>
+          <li>Save notes locally with instant autosave.</li>
+          <li>Review system status from the top bar.</li>
+        </ul>
+      </article>
+      <article data-template="notes">
+        <label for="notesArea">Sticky Notes</label>
+        <textarea id="notesArea" placeholder="Write something…"></textarea>
+        <p class="hint">Notes are stored locally in your browser.</p>
+      </article>
+      <article data-template="terminal">
+        <div class="terminal">
+          <p><strong>slopOS shell</strong> — type a command:</p>
+          <div class="terminal-output" id="terminalOutput"></div>
+          <form id="terminalForm">
+            <label>
+              <span>$</span>
+              <input id="terminalInput" autocomplete="off" />
+            </label>
+          </form>
+        </div>
+      </article>
+      <article data-template="gallery">
+        <div class="gallery">
+          <figure>
+            <div class="swatch swatch-a"></div>
+            <figcaption>Neon Harbor</figcaption>
+          </figure>
+          <figure>
+            <div class="swatch swatch-b"></div>
+            <figcaption>Night Sky</figcaption>
+          </figure>
+          <figure>
+            <div class="swatch swatch-c"></div>
+            <figcaption>Pulse Drive</figcaption>
+          </figure>
+        </div>
+      </article>
+    </template>
+
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,290 @@
+:root {
+  color-scheme: dark;
+  font-family: "Inter", "Segoe UI", system-ui, sans-serif;
+  --bg: #0b0f1e;
+  --panel: rgba(18, 24, 46, 0.92);
+  --accent: #52d0ff;
+  --accent-2: #a855f7;
+  --text: #e6f0ff;
+  --muted: #95a4c6;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(circle at top, #1b2a5b 0%, var(--bg) 60%);
+  color: var(--text);
+}
+
+.boot-screen {
+  position: fixed;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  gap: 1rem;
+  background: var(--bg);
+  z-index: 10;
+  text-align: center;
+}
+
+.boot-logo {
+  font-size: 2.8rem;
+  letter-spacing: 0.2rem;
+  text-transform: uppercase;
+}
+
+.boot-bar {
+  width: min(320px, 80vw);
+  height: 6px;
+  background: rgba(255, 255, 255, 0.1);
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.boot-bar span {
+  display: block;
+  height: 100%;
+  width: 40%;
+  background: linear-gradient(90deg, var(--accent), var(--accent-2));
+  animation: boot 1.6s ease-in-out infinite;
+}
+
+@keyframes boot {
+  0% {
+    transform: translateX(-120%);
+  }
+  50% {
+    transform: translateX(40%);
+  }
+  100% {
+    transform: translateX(120%);
+  }
+}
+
+.desktop {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.top-bar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 2rem;
+  background: rgba(10, 14, 30, 0.8);
+  backdrop-filter: blur(12px);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.brand {
+  font-weight: 700;
+  letter-spacing: 0.15rem;
+}
+
+.status {
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.workspace {
+  flex: 1;
+  display: grid;
+  grid-template-columns: 1fr minmax(280px, 420px);
+  gap: 2rem;
+  padding: 2rem;
+}
+
+.icon-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 1rem;
+  align-content: start;
+}
+
+.app-icon {
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 18px;
+  padding: 1.2rem;
+  color: inherit;
+  display: grid;
+  gap: 0.6rem;
+  justify-items: start;
+  cursor: pointer;
+  transition: transform 0.2s ease, border-color 0.2s ease;
+}
+
+.app-icon span {
+  font-size: 1.8rem;
+}
+
+.app-icon:hover,
+.app-icon:focus-visible {
+  transform: translateY(-4px);
+  border-color: rgba(82, 208, 255, 0.6);
+}
+
+.window {
+  background: var(--panel);
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.4);
+  min-height: 360px;
+}
+
+.window-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.8rem 1.2rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.window-header h2 {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.window-actions button {
+  background: transparent;
+  color: var(--muted);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 6px;
+  padding: 0.25rem 0.5rem;
+  margin-left: 0.4rem;
+  cursor: pointer;
+}
+
+.window-body {
+  padding: 1.4rem;
+  display: grid;
+  gap: 1rem;
+  font-size: 0.95rem;
+}
+
+.window.minimized .window-body {
+  display: none;
+}
+
+.window.minimized {
+  align-self: start;
+  height: auto;
+}
+
+textarea {
+  width: 100%;
+  min-height: 160px;
+  background: rgba(9, 12, 26, 0.8);
+  color: var(--text);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 12px;
+  padding: 0.8rem;
+  resize: vertical;
+}
+
+.hint {
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+.terminal {
+  display: grid;
+  gap: 0.8rem;
+}
+
+.terminal-output {
+  background: rgba(0, 0, 0, 0.4);
+  border-radius: 12px;
+  padding: 0.8rem;
+  max-height: 160px;
+  overflow-y: auto;
+  font-family: "Fira Code", monospace;
+  font-size: 0.85rem;
+}
+
+.terminal label {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  font-family: "Fira Code", monospace;
+}
+
+.terminal input {
+  flex: 1;
+  background: transparent;
+  border: none;
+  color: var(--text);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.2);
+  padding: 0.3rem;
+}
+
+.gallery {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(110px, 1fr));
+  gap: 0.8rem;
+}
+
+.gallery figure {
+  margin: 0;
+  display: grid;
+  gap: 0.4rem;
+  text-align: center;
+  color: var(--muted);
+}
+
+.swatch {
+  height: 80px;
+  border-radius: 12px;
+}
+
+.swatch-a {
+  background: linear-gradient(140deg, #1b2a5b, #52d0ff);
+}
+
+.swatch-b {
+  background: linear-gradient(140deg, #0f1c3c, #a855f7);
+}
+
+.swatch-c {
+  background: linear-gradient(140deg, #3f1d50, #ff7cd8);
+}
+
+.dock {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 0.8rem;
+  padding: 0.8rem 2rem 1.6rem;
+}
+
+.dock-button {
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 999px;
+  padding: 0.5rem 1.2rem;
+  color: var(--text);
+  cursor: pointer;
+}
+
+.dock-divider {
+  width: 1px;
+  height: 24px;
+  background: rgba(255, 255, 255, 0.2);
+}
+
+@media (max-width: 960px) {
+  .workspace {
+    grid-template-columns: 1fr;
+  }
+
+  .window {
+    order: -1;
+  }
+}


### PR DESCRIPTION
### Motivation
- Convert the repository into a browser-first web OS shell and make it deployable via GitHub Pages.

### Description
- Add `index.html` implementing a full-page web desktop shell with boot screen, dock, window chrome, and app templates for About, Notes, Terminal, and Gallery.
- Add `styles.css` providing the dark theme, layout, window styling, dock visuals, and responsive rules.
- Add `app.js` implementing client-side behaviors for launching apps, window minimize/close controls, persistent notes using `localStorage`, and a lightweight terminal with commands (`help`, `status`, `clear`, `time`).
- Update `README.md` with GitHub Pages deployment steps and a local preview command (`python3 -m http.server 8000`).

### Testing
- Started a local preview server with `python3 -m http.server 8000` and confirmed the static site was served before interrupting the process.
- Attempted an automated browser screenshot with Playwright, but headless Chromium crashed in this environment so the capture test failed.
- No unit or CI tests were added for this static site change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69818b1cb4c4832ca417605f0c0e01e2)