### PR TITLE
Add BoxedLang Studio app with editor, interpreter, and persistence

### DIFF
--- a/app.js
+++ b/app.js
@@ -11,6 +11,7 @@ const templates = document.getElementById("templates");
 const appState = {
   activeApp: "about",
   notesKey: "slopOS-notes",
+  boxedKey: "slopOS-boxed",
 };
 
 const appContent = {
@@ -26,11 +27,182 @@ const appContent = {
   gallery: {
     title: "Gallery",
   },
+  boxed: {
+    title: "BoxedLang Studio",
+  },
 };
 
 const terminalResponses = {
   help: "Available commands: help, status, clear, time",
   status: "All systems nominal. Network uplink stable.",
+};
+
+const boxedSample = `# BoxedLang Studio sample
+box greeting = "Hello from BoxedLang!"
+box count = 3
+
+say greeting
+math total = count * 4 + 2
+say total
+
+if total > 10 jump celebration
+say "Total is small."
+jump end
+
+mark celebration
+say "Total is big!"
+
+mark end
+say "Done."`;
+
+const parseBoxedValue = (value, variables, lineNumber) => {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    throw new Error(`Missing value on line ${lineNumber}.`);
+  }
+  if (
+    (trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+    (trimmed.startsWith("'") && trimmed.endsWith("'"))
+  ) {
+    return trimmed.slice(1, -1);
+  }
+  if (!Number.isNaN(Number(trimmed))) {
+    return Number(trimmed);
+  }
+  if (variables.has(trimmed)) {
+    return variables.get(trimmed);
+  }
+  throw new Error(`Unknown value "${trimmed}" on line ${lineNumber}.`);
+};
+
+const evaluateBoxedExpression = (expression, variables, lineNumber) => {
+  const replaced = expression.replace(
+    /\b[a-zA-Z_][a-zA-Z0-9_]*\b/g,
+    (token) => {
+      if (!variables.has(token)) {
+        throw new Error(`Unknown variable "${token}" on line ${lineNumber}.`);
+      }
+      const value = variables.get(token);
+      if (typeof value !== "number") {
+        throw new Error(`Variable "${token}" is not a number on line ${lineNumber}.`);
+      }
+      return String(value);
+    }
+  );
+
+  if (!/^[0-9+\-*/%().<>=!&|\s]+$/.test(replaced)) {
+    throw new Error(`Invalid characters in expression on line ${lineNumber}.`);
+  }
+
+  // eslint-disable-next-line no-new-func
+  return Function(`"use strict"; return (${replaced});`)();
+};
+
+const runBoxedProgram = (source) => {
+  const lines = source.split(/\r?\n/);
+  const labels = new Map();
+  const variables = new Map();
+  const output = [];
+
+  lines.forEach((line, index) => {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#") || trimmed.startsWith("//")) {
+      return;
+    }
+    const match = trimmed.match(/^mark\s+([a-zA-Z_][a-zA-Z0-9_]*)$/);
+    if (match) {
+      labels.set(match[1], index);
+    }
+  });
+
+  let pointer = 0;
+  while (pointer < lines.length) {
+    const raw = lines[pointer];
+    const trimmed = raw.trim();
+    const lineNumber = pointer + 1;
+
+    if (!trimmed || trimmed.startsWith("#") || trimmed.startsWith("//")) {
+      pointer += 1;
+      continue;
+    }
+
+    const [command] = trimmed.split(/\s+/);
+    const rest = trimmed.slice(command.length).trim();
+
+    try {
+      if (command === "box") {
+        const match = trimmed.match(
+          /^box\s+([a-zA-Z_][a-zA-Z0-9_]*)\s*(?:=\s*)?(.*)$/
+        );
+        if (!match || !match[2]) {
+          throw new Error(`Invalid box declaration on line ${lineNumber}.`);
+        }
+        const value = parseBoxedValue(match[2], variables, lineNumber);
+        variables.set(match[1], value);
+      } else if (command === "say") {
+        if (!rest) {
+          throw new Error(`Missing say message on line ${lineNumber}.`);
+        }
+        if (rest.startsWith("$")) {
+          const name = rest.slice(1).trim();
+          if (!variables.has(name)) {
+            throw new Error(`Unknown variable "${name}" on line ${lineNumber}.`);
+          }
+          output.push(String(variables.get(name)));
+        } else {
+          output.push(String(parseBoxedValue(rest, variables, lineNumber)));
+        }
+      } else if (command === "math") {
+        const match = trimmed.match(
+          /^math\s+([a-zA-Z_][a-zA-Z0-9_]*)\s*=\s*(.+)$/
+        );
+        if (!match) {
+          throw new Error(`Invalid math statement on line ${lineNumber}.`);
+        }
+        const value = evaluateBoxedExpression(match[2], variables, lineNumber);
+        variables.set(match[1], value);
+      } else if (command === "if") {
+        const match = trimmed.match(
+          /^if\s+(.+)\s+jump\s+([a-zA-Z_][a-zA-Z0-9_]*)$/
+        );
+        if (!match) {
+          throw new Error(`Invalid if statement on line ${lineNumber}.`);
+        }
+        const result = evaluateBoxedExpression(match[1], variables, lineNumber);
+        if (result) {
+          const labelLine = labels.get(match[2]);
+          if (labelLine === undefined) {
+            throw new Error(`Unknown mark "${match[2]}" on line ${lineNumber}.`);
+          }
+          pointer = labelLine;
+          continue;
+        }
+      } else if (command === "mark") {
+        // Labels are handled in the pre-pass.
+      } else if (command === "jump") {
+        const match = trimmed.match(/^jump\s+([a-zA-Z_][a-zA-Z0-9_]*)$/);
+        if (!match) {
+          throw new Error(`Invalid jump statement on line ${lineNumber}.`);
+        }
+        const labelLine = labels.get(match[1]);
+        if (labelLine === undefined) {
+          throw new Error(`Unknown mark "${match[1]}" on line ${lineNumber}.`);
+        }
+        pointer = labelLine;
+        continue;
+      } else {
+        throw new Error(`Unknown command "${command}" on line ${lineNumber}.`);
+      }
+    } catch (error) {
+      error.lineNumber = lineNumber;
+      error.sourceLine = raw;
+      throw error;
+    }
+
+    pointer += 1;
+  }
+
+  return output;
 };
 
 const setStatus = () => {
@@ -90,6 +262,47 @@ const renderApp = (appName) => {
       }
       input.value = "";
     });
+  }
+
+  if (appName === "boxed") {
+    const editor = windowBody.querySelector("#boxedEditor");
+    const outputPanel = windowBody.querySelector("#boxedOutput");
+    const runButton = windowBody.querySelector("#boxedRun");
+
+    const storedProgram = localStorage.getItem(appState.boxedKey);
+    editor.value = storedProgram ?? boxedSample;
+
+    const writeOutput = (lines) => {
+      outputPanel.innerHTML = "";
+      lines.forEach((line) => {
+        const p = document.createElement("p");
+        p.textContent = line;
+        outputPanel.appendChild(p);
+      });
+    };
+
+    const runProgram = () => {
+      try {
+        const output = runBoxedProgram(editor.value);
+        writeOutput(output.length ? output : ["(no output)"]);
+      } catch (error) {
+        const lineNumber = error.lineNumber ?? 0;
+        const sourceLine = error.sourceLine ?? "";
+        writeOutput([
+          `Error: ${error.message}`,
+          `Line ${lineNumber}: ${sourceLine.trim()}`,
+          `${" ".repeat(`Line ${lineNumber}: `.length)}^`,
+        ]);
+      }
+    };
+
+    editor.addEventListener("input", (event) => {
+      localStorage.setItem(appState.boxedKey, event.target.value);
+    });
+
+    runButton.addEventListener("click", runProgram);
+
+    runProgram();
   }
 };
 

--- a/index.html
+++ b/index.html
@@ -37,6 +37,10 @@
             <span>🖼️</span>
             <strong>Gallery</strong>
           </button>
+          <button class="app-icon" data-app="boxed">
+            <span>📦</span>
+            <strong>BoxedLang Studio</strong>
+          </button>
         </section>
 
         <section class="window" id="window" role="dialog" aria-modal="false">
@@ -58,6 +62,7 @@
         <button class="dock-button" data-app="notes">Notes</button>
         <button class="dock-button" data-app="terminal">Terminal</button>
         <button class="dock-button" data-app="gallery">Gallery</button>
+        <button class="dock-button" data-app="boxed">BoxedLang Studio</button>
       </footer>
     </div>
 
@@ -105,6 +110,25 @@
             <div class="swatch swatch-c"></div>
             <figcaption>Pulse Drive</figcaption>
           </figure>
+        </div>
+      </article>
+      <article data-template="boxed">
+        <div class="studio">
+          <div class="studio-editor">
+            <label for="boxedEditor">BoxedLang Editor</label>
+            <textarea id="boxedEditor" spellcheck="false"></textarea>
+            <div class="studio-actions">
+              <button id="boxedRun" type="button">Run</button>
+              <p class="hint">Saved automatically in your browser.</p>
+            </div>
+          </div>
+          <div class="studio-output">
+            <div class="studio-output-header">
+              <h4>Output</h4>
+              <span class="hint">Errors show line context.</span>
+            </div>
+            <div class="studio-output-panel" id="boxedOutput"></div>
+          </div>
         </div>
       </article>
     </template>

--- a/styles.css
+++ b/styles.css
@@ -225,6 +225,69 @@ textarea {
   padding: 0.3rem;
 }
 
+.studio {
+  display: grid;
+  gap: 1.2rem;
+}
+
+.studio-editor {
+  display: grid;
+  gap: 0.6rem;
+}
+
+.studio-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.studio-actions button {
+  background: linear-gradient(120deg, rgba(82, 208, 255, 0.4), rgba(168, 85, 247, 0.4));
+  color: var(--text);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 10px;
+  padding: 0.4rem 1.2rem;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.studio-output {
+  display: grid;
+  gap: 0.6rem;
+}
+
+.studio-output-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.studio-output-header h4 {
+  margin: 0;
+}
+
+.studio-output-panel {
+  background: rgba(0, 0, 0, 0.4);
+  border-radius: 12px;
+  padding: 0.8rem;
+  min-height: 140px;
+  max-height: 220px;
+  overflow-y: auto;
+  font-family: "Fira Code", monospace;
+  font-size: 0.85rem;
+  white-space: pre-wrap;
+}
+
+.studio-output-panel p {
+  margin: 0 0 0.5rem;
+}
+
+.studio-output-panel p:last-child {
+  margin-bottom: 0;
+}
+
 .gallery {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(110px, 1fr));


### PR DESCRIPTION
### Motivation
- Provide an integrated BoxedLang development experience in the slopOS web shell with an editor, Run button, and output panel following existing Studio UI patterns.
- Ship a simple in-browser interpreter so users can author and execute small BoxedLang programs without external tooling.
- Preserve editor contents across sessions using `localStorage` and give helpful error messages with line context similar to the Python studio.

### Description
- Added a BoxedLang launcher and a new template in `index.html` that includes a textarea editor, a `Run` button, and an output panel wired into the existing app window system.
- Added styles in `styles.css` (`.studio`, `.studio-editor`, `.studio-actions`, `.studio-output`, `.studio-output-panel`) to match the existing Studio UI and ensure readable monospaced output.
- Implemented BoxedLang support in `app.js`: new `appState.boxedKey`, `appContent.boxed`, a `boxedSample` program demonstrating `box`, `say`, `math`, `if`, `mark`, and `jump`, parsing helpers (`parseBoxedValue`, `evaluateBoxedExpression`), a `runBoxedProgram` interpreter that handles labels, variables, commands and throws errors with `lineNumber` and `sourceLine`, plus UI handling that autosaves editor contents to `localStorage`, runs the interpreter on `Run`, and displays output or error lines with line context.

### Testing
- Started a local HTTP server (`python -m http.server 8000`) to serve the UI, which launched successfully.
- Attempted an automated Playwright script to open the page and capture a screenshot, but the Playwright run timed out and failed.
- No other automated test suite was executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69828aa18c80832cb653fe0637f0933f)