### PR TITLE
Add BoxedLang interpreter and Files app runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,37 @@ python3 -m http.server 8000
 ```
 
 Then visit <http://localhost:8000>.
+
+## BoxedLang
+
+slopOS ships with a tiny scripting language called **BoxedLang** for demos and
+automation. Scripts are stored in the virtual filesystem and use this format:
+
+```
+<cmd> <arg1>|<arg2>|...
+```
+
+### Example
+
+```
+box name|slopOS
+say Welcome~to~$name
+```
+
+### Commands
+
+- `box <name>|<value>`: Store a value in a box.
+- `say <message>`: Print a line (`~` becomes a space).
+- `ask <box>|<prompt>`: Prompt for input and store the response.
+- `del <box>`: Remove a stored value.
+- `test <left>|<right>`: Compare values.
+- `math <box>|<left>|<op>|<right>`: Basic math (`+`, `-`, `*`, `/`).
+- `wait <ms>`: Placeholder for delays.
+- `mark <name>` / `jump <name>`: Labels and jumps.
+- `if <left>|<right>`: Skip the next line if the values do not match.
+- `jumpif <mark>|<left>|<right>`: Jump to a mark when values match.
+
+### Running scripts
+
+- **Terminal:** `boxed <filename>` runs a `.box` file from the virtual filesystem.
+- **Files app:** select a `.box` file and press **Run** to see the output.

--- a/boxedlang.js
+++ b/boxedlang.js
@@ -1,0 +1,143 @@
+const normalizeArg = (value, boxes) => {
+  let normalized = value;
+  if (normalized.startsWith("$")) {
+    const key = normalized.slice(1);
+    normalized = boxes[key] ?? "";
+  }
+  return normalized.replace(/~/g, " ").replace(/:/g, "");
+};
+
+const pullCmdFrom = (line) => {
+  const trimmed = line.trim();
+  if (!trimmed || trimmed.startsWith("#")) {
+    return null;
+  }
+  const [cmd, ...rest] = trimmed.split(" ");
+  const argString = rest.join(" ").trim();
+  const args = argString ? argString.split("|").map((arg) => arg.trim()) : [];
+  return { cmd: cmd.toLowerCase(), args };
+};
+
+const makeCodeFrom = (text) =>
+  text
+    .split(/\r?\n/)
+    .map((line) => pullCmdFrom(line))
+    .filter(Boolean);
+
+const mk = (value) => value.replace(/ /g, "~").replace(/:/g, "");
+
+const undoMk = (value) => value.replace(/~/g, " ");
+
+const handleCommand = (state, instruction, outputLines, inputProvider) => {
+  const { cmd, args } = instruction;
+  const getArg = (index) => normalizeArg(args[index] ?? "", state.boxes);
+
+  if (cmd === "box") {
+    const key = getArg(0);
+    state.boxes[key] = getArg(1);
+    return;
+  }
+
+  if (cmd === "say") {
+    outputLines.push(getArg(0));
+    return;
+  }
+
+  if (cmd === "ask") {
+    const key = getArg(0);
+    const promptText = getArg(1) || "?";
+    const response = inputProvider ? inputProvider(promptText) : window.prompt(promptText);
+    state.boxes[key] = response ?? "";
+    return;
+  }
+
+  if (cmd === "del") {
+    const key = getArg(0);
+    delete state.boxes[key];
+    return;
+  }
+
+  if (cmd === "test") {
+    const left = getArg(0);
+    const right = getArg(1);
+    state.lastTest = left === right;
+    return;
+  }
+
+  if (cmd === "math") {
+    const key = getArg(0);
+    const left = parseFloat(getArg(1));
+    const op = getArg(2);
+    const right = parseFloat(getArg(3));
+    let result = left;
+    if (op === "+") {
+      result = left + right;
+    } else if (op === "-") {
+      result = left - right;
+    } else if (op === "*") {
+      result = left * right;
+    } else if (op === "/") {
+      result = right === 0 ? 0 : left / right;
+    }
+    state.boxes[key] = Number.isNaN(result) ? "" : String(result);
+    return;
+  }
+
+  if (cmd === "wait") {
+    return;
+  }
+
+  if (cmd === "mark") {
+    const key = getArg(0);
+    state.marks[key] = state.line;
+    return;
+  }
+
+  if (cmd === "jump") {
+    const key = getArg(0);
+    if (state.marks[key] !== undefined) {
+      state.line = state.marks[key];
+    }
+    return;
+  }
+
+  if (cmd === "if") {
+    const left = getArg(0);
+    const right = getArg(1);
+    state.lastTest = left === right;
+    if (!state.lastTest) {
+      state.line += 1;
+    }
+    return;
+  }
+
+  if (cmd === "jumpif") {
+    const key = getArg(0);
+    const left = getArg(1);
+    const right = getArg(2);
+    if (left === right && state.marks[key] !== undefined) {
+      state.line = state.marks[key];
+    }
+  }
+};
+
+const runBoxedCode = (text, options = {}) => {
+  const code = Array.isArray(text) ? text : makeCodeFrom(text);
+  const state = {
+    boxes: {},
+    marks: {},
+    line: 0,
+    lastTest: false,
+  };
+  const outputLines = [];
+
+  while (state.line < code.length) {
+    const instruction = code[state.line];
+    handleCommand(state, instruction, outputLines, options.inputProvider);
+    state.line += 1;
+  }
+
+  return outputLines;
+};
+
+export { pullCmdFrom, makeCodeFrom, mk, undoMk, runBoxedCode };

--- a/index.html
+++ b/index.html
@@ -33,6 +33,10 @@
             <span>💻</span>
             <strong>Terminal</strong>
           </button>
+          <button class="app-icon" data-app="files">
+            <span>🗂️</span>
+            <strong>Files</strong>
+          </button>
           <button class="app-icon" data-app="gallery">
             <span>🖼️</span>
             <strong>Gallery</strong>
@@ -57,6 +61,7 @@
         <button class="dock-button" data-app="about">About</button>
         <button class="dock-button" data-app="notes">Notes</button>
         <button class="dock-button" data-app="terminal">Terminal</button>
+        <button class="dock-button" data-app="files">Files</button>
         <button class="dock-button" data-app="gallery">Gallery</button>
       </footer>
     </div>
@@ -91,6 +96,25 @@
           </form>
         </div>
       </article>
+      <article data-template="files">
+        <div class="files">
+          <aside class="files-list">
+            <h4>Virtual Files</h4>
+            <div id="fileList" class="file-list"></div>
+          </aside>
+          <section class="files-viewer">
+            <header class="files-header">
+              <h4 id="fileName">Select a file</h4>
+              <button id="runBoxed" type="button" hidden>Run</button>
+            </header>
+            <textarea id="fileViewer" readonly></textarea>
+            <div class="files-output">
+              <h5>Output</h5>
+              <pre id="filesOutput">(no output)</pre>
+            </div>
+          </section>
+        </div>
+      </article>
       <article data-template="gallery">
         <div class="gallery">
           <figure>
@@ -109,6 +133,6 @@
       </article>
     </template>
 
-    <script src="app.js"></script>
+    <script type="module" src="app.js"></script>
   </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -225,6 +225,79 @@ textarea {
   padding: 0.3rem;
 }
 
+.files {
+  display: grid;
+  grid-template-columns: minmax(160px, 220px) 1fr;
+  gap: 1rem;
+}
+
+.files-list {
+  background: rgba(0, 0, 0, 0.2);
+  border-radius: 12px;
+  padding: 0.8rem;
+  display: grid;
+  gap: 0.6rem;
+}
+
+.file-list {
+  display: grid;
+  gap: 0.4rem;
+}
+
+.file-entry {
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 8px;
+  color: var(--text);
+  padding: 0.4rem 0.6rem;
+  text-align: left;
+  cursor: pointer;
+}
+
+.files-viewer {
+  display: grid;
+  gap: 0.8rem;
+}
+
+.files-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.files-header button {
+  background: var(--accent);
+  color: #041026;
+  border: none;
+  padding: 0.35rem 0.8rem;
+  border-radius: 999px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.files-viewer textarea {
+  min-height: 140px;
+  font-family: "Fira Code", monospace;
+  font-size: 0.85rem;
+}
+
+.files-output {
+  background: rgba(0, 0, 0, 0.3);
+  border-radius: 12px;
+  padding: 0.8rem;
+  display: grid;
+  gap: 0.4rem;
+}
+
+.files-output pre {
+  margin: 0;
+  white-space: pre-wrap;
+  font-family: "Fira Code", monospace;
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
 .gallery {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(110px, 1fr));
@@ -281,6 +354,10 @@ textarea {
 
 @media (max-width: 960px) {
   .workspace {
+    grid-template-columns: 1fr;
+  }
+
+  .files {
     grid-template-columns: 1fr;
   }
 


### PR DESCRIPTION
### Motivation

- Provide a small scripting/demo language (BoxedLang) for the demo OS and allow running `.box` scripts from the terminal and a Files UI. 
- Reuse parsing helpers and interpreter behavior to keep script format consistent with prior tooling and support common commands like `box`, `say`, `ask`, `jump`, and `math`.

### Description

- Add `boxedlang.js` implementing parsing helpers `pullCmdFrom`, `makeCodeFrom`, `mk`, `undoMk` and an interpreter exposing `runBoxedCode` and internal `handleCommand` with state (`boxes`, `marks`, `line`, `lastTest`) and support for `box`, `say`, `ask`, `del`, `test`, `math`, `wait`, `mark`, `jump`, `if`, and `jumpif` plus token replacement rules (`$box`, `~` -> space, remove `:`).
- Update `app.js` to import `runBoxedCode`, add a `virtualFiles` store, add terminal commands `ls`, `cat <file>`, and `boxed <file>`, and wire interpreter output into the terminal via `appendTerminalLine` / `renderTerminalLine`.
- Add a Files app UI in `index.html` with a file list, file viewer and a `Run` button for `.box` files, and implement file-run logic in `app.js` to stream output into the Files app output panel.
- Add styling for the Files app in `styles.css` and document BoxedLang usage, example syntax, commands, and how to run scripts in `README.md`.

### Testing

- Launched a local HTTP server with `python3 -m http.server 8000` to serve the site (server started successfully). 
- Fetched `index.html` with `curl -I http://127.0.0.1:8000/index.html` and received `HTTP/1.0 200 OK`, confirming files served correctly.
- Attempted an automated UI screenshot via Playwright to capture the Files app view, but Playwright timed out / crashed in this environment so the end-to-end browser test failed.
- All changes were staged and committed as part of the update (new file `boxedlang.js` added and other files updated).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69828a9d904c832ca1a3c5024433151a)