### PR TITLE
Add inline favicon to prevent 404

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>slopOS Web</title>
+    <link rel="icon" href="data:," />
     <link rel="stylesheet" href="styles.css" />
   </head>
   <body>


### PR DESCRIPTION
### Motivation
- Prevent the browser from requesting a missing `favicon.ico`, which caused 404 errors in the console.

### Description
- Insert a single-line inline favicon tag `<link rel="icon" href="data:," />` into the `<head>` of `index.html` to stop the browser from attempting to fetch a non-existent favicon.

### Testing
- No automated tests were run for this trivial HTML change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69828cffce88832c987a92aedbb13635)