### PR TITLE
Skip slopOS boot delay

### DIFF
--- a/app.js
+++ b/app.js
@@ -330,10 +330,8 @@ closeButton.addEventListener("click", () => {
 
 setInterval(setStatus, 1000);
 
-setTimeout(() => {
-  bootScreen.hidden = true;
-  desktop.hidden = false;
-  setStatus();
-  renderApp("about");
-  attachAppLaunchers();
-}, 1200);
+bootScreen.hidden = true;
+desktop.hidden = false;
+setStatus();
+renderApp("about");
+attachAppLaunchers();


### PR DESCRIPTION
### Motivation
- Remove the artificial 1.2s boot delay so the desktop initializes and is visible immediately instead of stalling on the "Initializing web OS services…" screen.

### Description
- Replace the `setTimeout(..., 1200)` boot sequence in `app.js` with immediate initialization by unhiding the desktop and calling `setStatus()`, `renderApp("about")`, and `attachAppLaunchers()` at script load time.

### Testing
- Started a local server with `python -m http.server 8000` and ran a Playwright script that loaded `/index.html` and captured `artifacts/slopos-booted.png`, which completed successfully and shows the desktop rendered immediately. 
- No unit tests were added or changed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69828e3a1234832cb274ec2d54f86910)