### PR TITLE
Remove lingering boot screen element and initialize desktop immediately

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,4 +1,4 @@
-const bootScreen = document.getElementById("bootScreen");
+const bootScreen = document.querySelector("#bootScreen");
 const desktop = document.getElementById("desktop");
 const status = document.getElementById("status");
 const windowPane = document.getElementById("window");
@@ -330,10 +330,8 @@ closeButton.addEventListener("click", () => {
 
 setInterval(setStatus, 1000);
 
-setTimeout(() => {
-  bootScreen.hidden = true;
-  desktop.hidden = false;
-  setStatus();
-  renderApp("about");
-  attachAppLaunchers();
-}, 1200);
+bootScreen?.remove();
+desktop.hidden = false;
+setStatus();
+renderApp("about");
+attachAppLaunchers();


### PR DESCRIPTION
### Motivation
- Ensure the boot screen does not linger and the desktop is visible immediately after script load by removing the artificial boot sequence and fixing the boot screen lookup.
- Use a more robust selector and removal approach so the boot UI cannot accidentally remain visible over the desktop.

### Description
- Replace `document.getElementById("bootScreen")` with `document.querySelector("#bootScreen")` for consistency.
- Remove the boot screen element using `bootScreen?.remove()` instead of setting `hidden`, and perform immediate initialization with `desktop.hidden = false`, `setStatus()`, `renderApp("about")`, and `attachAppLaunchers()`.
- Preserve existing background status refresh via `setInterval(setStatus, 1000)` and existing window event listeners.

### Testing
- Started a local server with `python -m http.server 8000` and ran a Playwright script that loaded `/index.html` and captured `artifacts/slopos-booted.png`, and the script completed successfully.
- No unit tests were added or changed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69828e3a1234832cb274ec2d54f86910)