### PR TITLE
Fix launcher overlay behavior and window action responsiveness

### DIFF
--- a/app.js
+++ b/app.js
@@ -403,6 +403,10 @@ const createWindow = (appName) => {
   actions.append(minimizeButton, maximizeButton, closeButton);
   header.append(title, actions);
 
+  actions.addEventListener("pointerdown", (event) => {
+    event.stopPropagation();
+  });
+
   const body = document.createElement("div");
   body.className = "window-body";
   const template = templates.content.querySelector(
@@ -507,9 +511,10 @@ const attachAppLaunchers = () => {
     button.addEventListener("click", () => {
       const app = button.dataset.app;
       if (app === "launcher") {
-        setLauncherVisibility(true);
+        setLauncherVisibility(launcher.hidden);
         return;
       }
+      setLauncherVisibility(false);
       launchApp(app);
     });
   });
@@ -517,7 +522,13 @@ const attachAppLaunchers = () => {
 
 launcherSearch.addEventListener("input", renderLauncher);
 launcherClose.addEventListener("click", () => setLauncherVisibility(false));
-activitiesButton.addEventListener("click", () => setLauncherVisibility(true));
+activitiesButton.addEventListener("click", () => setLauncherVisibility(launcher.hidden));
+
+launcher.addEventListener("click", (event) => {
+  if (event.target === launcher) {
+    setLauncherVisibility(false);
+  }
+});
 
 window.addEventListener("keydown", (event) => {
   if (event.key === "Escape" && !launcher.hidden) {


### PR DESCRIPTION
### Motivation
- The Activities/launcher overlay could get stuck open and block the desktop, making app launches feel broken. 
- Window header drag handling intercepted clicks on the close/minimize/maximize controls, preventing windows from closing or being minimized. 
- Users need a reliable way to dismiss the launcher (backdrop click / toggle) and to launch apps without the overlay persisting.

### Description
- Stop pointer event propagation on the window actions container by adding a `pointerdown` handler to `actions` so header drag no longer interferes with button clicks in `createWindow` (`app.js`).
- Make the dock launcher and `activitiesButton` act as toggles by calling `setLauncherVisibility(launcher.hidden)` so the launcher opens and closes predictably from both controls (`app.js`).
- Ensure clicking any non-launcher app first dismisses the launcher via `setLauncherVisibility(false)` before calling `launchApp`, returning focus to the desktop (`app.js`).
- Add backdrop dismissal by listening for clicks on the `launcher` element and closing it when the backdrop (not the panel) is clicked (`app.js`).

### Testing
- Ran `node --check app.js` which completed successfully. 
- Automated Playwright run against Chromium failed due to an environment crash (SIGSEGV) and could not complete. 
- Automated Playwright run against Firefox failed with `NS_ERROR_NET_RESET` while navigating to the local server and could not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991315a725c832cbfe6f56601628117)